### PR TITLE
feat: Convert payment amount to cents for Stripe payment intent creation

### DIFF
--- a/ansible/roles/payment/files/payment/volumes/functions/payments/gateways/stripe.ts
+++ b/ansible/roles/payment/files/payment/volumes/functions/payments/gateways/stripe.ts
@@ -37,8 +37,9 @@ async function createStripeIntent({
   customerId: string;
 }): Promise<CreatePaymentResponse> {
   try {
+    const amountInCents = amount * 100; // Stripe requires amount in cents
     const paymentIntent = await stripe.paymentIntents.create({
-      amount,
+      amount: amountInCents,
       currency,
       metadata: {
         order_id: orderId,


### PR DESCRIPTION
This pull request includes a small but important change to the `createStripeIntent` function in `stripe.ts`. The change ensures the payment amount is converted to cents, as required by Stripe's API.

* [`ansible/roles/payment/files/payment/volumes/functions/payments/gateways/stripe.ts`](diffhunk://#diff-fca1c8470dc8be6bd18c76ab5be54509dd0bbca8c28630e46c744f88cbb5601bR40-R42): Added a conversion of the `amount` to cents (`amountInCents`) before passing it to the `stripe.paymentIntents.create` method.