### PR TITLE
Add gateway_response column to orders

### DIFF
--- a/ansible/roles/payment/files/payment/volumes/db/migrations/20250430164224_alter_column_gateway_response_to_order.sql
+++ b/ansible/roles/payment/files/payment/volumes/db/migrations/20250430164224_alter_column_gateway_response_to_order.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE orders
+ADD COLUMN gateway_response JSON DEFAULT NULL;
+
+-- migrate:down
+ALTER TABLE orders
+DROP COLUMN gateway_response;

--- a/ansible/roles/payment/files/payment/volumes/db/seeds/product_table.sql
+++ b/ansible/roles/payment/files/payment/volumes/db/seeds/product_table.sql
@@ -1,0 +1,4 @@
+INSERT INTO "public"."product" ("product_id", "name", "description", "price", "created_at", "updated_at")
+VALUES
+    ('4cf70de1-35d6-4794-a249-9b79c328f086', 'Booking Fee', 'General booking fee for appointments', 10000, now(), now()),
+ON CONFLICT DO NOTHING;

--- a/ansible/roles/payment/files/payment/volumes/functions/payments/handlers/initiate.ts
+++ b/ansible/roles/payment/files/payment/volumes/functions/payments/handlers/initiate.ts
@@ -240,6 +240,27 @@ export const handleInitiate = async (c: Context) => {
         throw error;
       }
     }
+    // update order "gateway_response" with the response from the payment gateway
+    const { error: updateOrderError } = await paymentSupabaseAdmin
+      .from("orders")
+      .update({
+        gateway_response: response,
+        updated_at: new Date(),
+      })
+      .eq("order_id", orderId);
+
+    if (updateOrderError) {
+      await rollbackOrder(orderData.order_id);
+      console.error("Error updating order:", updateOrderError);
+      return c.json(
+        {
+          is_successful: false,
+          message: "Failed to update order",
+        },
+        500
+      );
+    }
+    
     return c.json({
       is_successful: true,
       message: "Payment initiated successfully",

--- a/ansible/roles/payment/files/payment/volumes/functions/payments/handlers/order.ts
+++ b/ansible/roles/payment/files/payment/volumes/functions/payments/handlers/order.ts
@@ -41,6 +41,7 @@ export const handleOrderStatus = async (c: Context) => {
       total_amount,
       created_at,
       updated_at,
+      gateway_response,
       order_items (
         order_item_id,
         product:products (product_id,name),


### PR DESCRIPTION
This pull request introduces a new feature to store the payment gateway's response in the `orders` table and updates the related handler function to handle this functionality. The most important changes include creating a database migration to add a `gateway_response` column and updating the `handleInitiate` function to save the gateway response and handle potential errors.

### Database changes:
* [`ansible/roles/payment/files/payment/volumes/db/migrations/20250430164224_alter_column_gateway_response_to_order.sql`](diffhunk://#diff-ca94851fbb5711d5e2245ca3ca4b1f555446f07e6682fed039245b66e07b5834R1-R7): Added a new `gateway_response` column of type `JSON` to the `orders` table with a default value of `NULL`. This migration includes both `up` and `down` steps for adding and removing the column.

### Application logic changes:
* [`ansible/roles/payment/files/payment/volumes/functions/payments/handlers/initiate.ts`](diffhunk://#diff-fb3d28a425fa27b8495fccc339dcc7f53f030c42ce9976eb7aecf1540aba5a8aR243-R263): Updated the `handleInitiate` function to store the payment gateway's response in the `gateway_response` column of the `orders` table. Added error handling to roll back the order and return an appropriate error response if the update fails.