### PR TITLE
Integrate Kuala Swagger with Docker Compose

### DIFF
--- a/.github/workflows/kuala.yml
+++ b/.github/workflows/kuala.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Copy kuala-api spec
         run: |
-          cp -r submodules/kuala-api/spec/openapi.yml ansible/roles/kuala/files/kuala-swagger/
+          if [ -f "submodules/kuala-api/spec/openapi.yml" ]; then
+            cp submodules/kuala-api/spec/openapi.yml ansible/roles/kuala/files/kuala-swagger/
+          else
+            echo "Error: openapi.yml not found in submodule" && exit 1
+          fi
 
       - name: Copy deno.json to kuala ansible role
         run: |

--- a/.github/workflows/kuala.yml
+++ b/.github/workflows/kuala.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - ansible/roles/kuala/**
+      - ansible/roles/kuala/files/kuala-swagger/**
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,6 +26,10 @@ jobs:
       - name: Copy kuala-api functions to kuala ansible role
         run: |
           cp -r submodules/kuala-api/supabase/functions/* ansible/roles/kuala/files/kuala/volumes/functions/
+
+      - name: Copy kuala-api spec
+        run: |
+          cp -r submodules/kuala-api/spec/openapi.yml ansible/roles/kuala/files/kuala-swagger/
 
       - name: Copy deno.json to kuala ansible role
         run: |

--- a/ansible/playbook/kuala-swagger.yaml
+++ b/ansible/playbook/kuala-swagger.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  roles:
+  - 'roles/common'
+  - role: roles/kuala
+    tags: kuala

--- a/ansible/roles/kuala/files/kuala-swagger/docker-compose.yml
+++ b/ansible/roles/kuala/files/kuala-swagger/docker-compose.yml
@@ -1,0 +1,27 @@
+name: kuala-swagger
+services:
+    openapi_mock:
+        container_name: kuala-openapi-mock
+        image: muonsoft/openapi-mock
+        environment:
+            OPENAPI_MOCK_SPECIFICATION_URL: "/app/openapi.yml"
+        volumes:
+            - ./openapi.yml:/app/openapi.yml
+        networks:
+            - kuala_default
+    swagger-ui:
+        image: swaggerapi/swagger-ui
+        container_name: kuala-swagger-ui
+        environment:
+            SWAGGER_JSON: "/app/openapi.yml"
+        volumes:
+            - ./openapi.yml:/app/openapi.yml
+        ports:
+            - "8081:8080"
+        networks:
+            - kuala_default
+
+networks:
+    kuala_default:
+        name: kuala_default
+        external: true

--- a/ansible/roles/kuala/files/kuala-swagger/docker-compose.yml
+++ b/ansible/roles/kuala/files/kuala-swagger/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     openapi_mock:
         container_name: kuala-openapi-mock
         image: muonsoft/openapi-mock
+        restart: unless-stopped
         environment:
             OPENAPI_MOCK_SPECIFICATION_URL: "/app/openapi.yml"
         volumes:
@@ -12,6 +13,7 @@ services:
     swagger-ui:
         image: swaggerapi/swagger-ui
         container_name: kuala-swagger-ui
+        restart: unless-stopped
         environment:
             SWAGGER_JSON: "/app/openapi.yml"
         volumes:

--- a/ansible/roles/kuala/tasks/apps.yaml
+++ b/ansible/roles/kuala/tasks/apps.yaml
@@ -4,20 +4,37 @@
     src: ../files/kuala
     dest: /opt
 
+- name: copy kuala swagger files
+  copy:
+    src: ../files/kuala-swagger
+    dest: /opt
+
 - name: Ensure rabbitmq network exists
   community.docker.docker_network:
     name: rabbitmq
     state: present
 
-- name: deploy/restart kuala apps 
+- name: deploy/restart kuala apps
   community.docker.docker_compose_v2:
     project_src: /opt/kuala
-    files: 
+    files:
       - "docker-compose.yaml"
       - "docker-compose-s3.yaml"
     state: present
   register: output
 
+- name: deploy/restart kuala swagger apps
+  community.docker.docker_compose_v2:
+    project_src: /opt/kuala-swagger
+    files:
+      - "docker-compose.yml"
+    state: present
+  register: swagger_output
+
 - name: Show results
   ansible.builtin.debug:
     var: output
+
+- name: Show kuala swagger results
+  ansible.builtin.debug:
+    var: swagger_output

--- a/ansible/roles/reverse-proxy/files/reverse-proxy/conf.d/kuala-api-staging.seribasa.digital.conf
+++ b/ansible/roles/reverse-proxy/files/reverse-proxy/conf.d/kuala-api-staging.seribasa.digital.conf
@@ -32,4 +32,23 @@ server {
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
         add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
     }    
+
+    location = /swagger {
+        return 301 /swagger/;
+    }
+
+    location /swagger/ {
+        set $endpoint kuala-swagger-ui:8080;
+        rewrite ^/swagger/?(.*)$ /$1 break;
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://$endpoint;    
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;  
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port    443;
+        proxy_set_header X-Request-ID $request_id;
+    }
 }


### PR DESCRIPTION
This pull request introduces infrastructure to deploy and serve the kuala OpenAPI specification and a Swagger UI for API documentation and mocking. It updates the deployment pipeline, adds new Ansible playbooks and tasks, configures Docker Compose for the Swagger services, and updates the reverse proxy to expose the Swagger UI.

**Swagger/OpenAPI deployment and serving:**

* Added `ansible/roles/kuala/files/kuala-swagger/docker-compose.yml` to define two services: an OpenAPI mock server (`muonsoft/openapi-mock`) and a Swagger UI (`swaggerapi/swagger-ui`), both serving the `openapi.yml` spec.
* Updated the Ansible `apps.yaml` tasks to copy Swagger files to `/opt`, deploy/restart the Swagger services via Docker Compose, and output deployment results. [[1]](diffhunk://#diff-0f157a1d06d303abe01757bae2e66e4e8222f145101fc83114a1738817bf1d23R7-R11) [[2]](diffhunk://#diff-0f157a1d06d303abe01757bae2e66e4e8222f145101fc83114a1738817bf1d23R26-R40)
* Added a new Ansible playbook `ansible/playbook/kuala-swagger.yaml` to deploy the Swagger/OpenAPI services as part of the `kuala` role.

**CI/CD pipeline improvements:**

* Updated `.github/workflows/kuala.yml` to copy the OpenAPI spec from the `kuala-api` submodule into the deployment directory and trigger on changes to the new Swagger files. [[1]](diffhunk://#diff-d08d1d2b560a2f39acf216b41cd07796ce19a3cd55272fd8615755a40d39883aR9) [[2]](diffhunk://#diff-d08d1d2b560a2f39acf216b41cd07796ce19a3cd55272fd8615755a40d39883aR30-R33)

**Reverse proxy configuration:**

* Updated the Nginx configuration to route `/swagger/` requests to the Swagger UI service, making the API documentation accessible via the reverse proxy.

**Submodule update:**

* Updated the `submodules/kuala-api` reference to the latest commit.